### PR TITLE
Fix #11 copying of mutex by defining methods on eventBus pointer rather than value

### DIFF
--- a/eventbus.go
+++ b/eventbus.go
@@ -12,7 +12,7 @@ type EventBus struct {
 	events map[string][]DataChannel
 }
 
-func (e EventBus) Subscribe(eventName string, ch DataChannel) {
+func (e *EventBus) Subscribe(eventName string, ch DataChannel) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
@@ -24,7 +24,7 @@ func (e EventBus) Subscribe(eventName string, ch DataChannel) {
 	e.events[eventName] = []DataChannel{ch}
 }
 
-func (e EventBus) UnSubscribe(eventName string, ch DataChannel) {
+func (e *EventBus) UnSubscribe(eventName string, ch DataChannel) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 

--- a/eventbus.go
+++ b/eventbus.go
@@ -51,7 +51,7 @@ func (e *EventBus) UnSubscribe(eventName string, ch DataChannel) {
 	}
 }
 
-func (e EventBus) Publish(eventName string, data Data) {
+func (e *EventBus) Publish(eventName string, data Data) {
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()
 
@@ -59,11 +59,9 @@ func (e EventBus) Publish(eventName string, data Data) {
 	if !ok {
 		return
 	}
-	go func() {
-		for _, ch := range subscribers {
-			ch <- data
-		}
-	}()
+	for _, ch := range subscribers {
+		ch <- data
+	}
 }
 
 func swap(i, j int, subscribers []DataChannel) {


### PR DESCRIPTION
This PR fixes #11. There were multiple reasons for the race condition. One being coping of a mutex which is not recommended. Also, in `Publish()`, while writing to channels we spawn a new goroutine which is being called asynchronously. So, the acquired lock in `Publish()` is being released even when `subscribers` list is still being read. I changed the code so that this is done synchronously.